### PR TITLE
Fix missing intro

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@ wordview
 |Python 3.9|
 
 .. include:: docs/source/intro.rst
+   :start-after: inclusion-marker-do-not-remove
 
 
 Features

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,14 @@ wordview
 
 |Python 3.9|
 
-.. include:: docs/source/intro.rst
-   :start-after: inclusion-marker-do-not-remove
+
+``wordview`` is a Python package for text analysis. It, moreover,
+provides a number of functionalities for Information Extraction and
+Preprocessing. See section `Features <#Features>`__ for more details.
+``wordview``\ ’s Python API is open-source and available under the `MIT
+license <https://en.wikipedia.org/wiki/MIT_License>`__. We, however,
+offer a web app under a commercial license. See `this page <>`__ for
+more information about the web-app-based version of ``wordview``.
 
 
 Features

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,14 @@
 
 Welcome to wordview's documentation!
 ====================================
-.. include:: intro.rst
+
+``wordview`` is a Python package for text analysis. It, moreover,
+provides a number of functionalities for Information Extraction and
+Preprocessing. See section `Features <#Features>`__ for more details.
+``wordview``\ ’s Python API is open-source and available under the `MIT
+license <https://en.wikipedia.org/wiki/MIT_License>`__. We, however,
+offer a web app under a commercial license. See `this page <>`__ for
+more information about the web-app-based version of ``wordview``.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,8 +1,0 @@
-.. inclusion-marker-do-not-remove
-``wordview`` is a Python package for text analysis. It, moreover,
-provides a number of functionalities for Information Extraction and
-Preprocessing. See section `Features <#Features>`__ for more details.
-``wordview``\ ’s Python API is open-source and available under the `MIT
-license <https://en.wikipedia.org/wiki/MIT_License>`__. We, however,
-offer a web app under a commercial license. See `this page <>`__ for
-more information about the web-app-based version of ``wordview``.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,3 +1,4 @@
+.. inclusion-marker-do-not-remove
 ``wordview`` is a Python package for text analysis. It, moreover,
 provides a number of functionalities for Information Extraction and
 Preprocessing. See section `Features <#Features>`__ for more details.


### PR DESCRIPTION
Intro was missing from the readme apparently because GitHub does not allow include in the main readme.